### PR TITLE
request camera permission before DrawAR

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,28 +17,47 @@
     package="com.googlecreativelab.drawar">
 
     <uses-permission android:name="android.permission.CAMERA" />
-    <!-- This tag indicates that this application requires ARCore.  This results in the application
-         only being visible in the Google Play Store on devices that support ARCore. -->
-    <uses-feature android:name="android.hardware.camera.ar" android:required="true"/>
+    <!--
+         This tag indicates that this application requires ARCore.  This results in the application
+         only being visible in the Google Play Store on devices that support ARCore.
+    -->
+    <uses-feature
+        android:name="android.hardware.camera.ar"
+        android:required="true" />
+
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
-        <activity
-            android:name=".DrawAR"
+        android:theme="@style/AppTheme">
+
+        <activity android:name=".FakeMainActivity"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"
             android:screenOrientation="locked"
             android:theme="@style/Theme.AppCompat.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <!-- This tag indicates that this application requires ARCore.  This results in the Google Play
-     Store downloading and installing ARCore along with the application. -->
-        <meta-data android:name="com.google.ar.core" android:value="required" />
+
+        <activity
+            android:name=".DrawAR"
+            android:configChanges="orientation|screenSize"
+            android:label="@string/app_name"
+            android:screenOrientation="locked"
+            android:theme="@style/Theme.AppCompat.NoActionBar">
+
+        </activity>
+        <!--
+     This tag indicates that this application requires ARCore.  This results in the Google Play
+     Store downloading and installing ARCore along with the application.
+        -->
+        <meta-data
+            android:name="com.google.ar.core"
+            android:value="required" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/googlecreativelab/drawar/DrawAR.java
+++ b/app/src/main/java/com/googlecreativelab/drawar/DrawAR.java
@@ -289,13 +289,6 @@ public class DrawAR extends AppCompatActivity implements GLSurfaceView.Renderer,
                         break;
                 }
 
-                // ARCore requires camera permissions to operate. If we did not yet obtain runtime
-                // permission on Android M and above, now is a good time to ask the user for it.
-                if (!PermissionHelper.hasCameraPermission(this)) {
-                    PermissionHelper.requestCameraPermission(this);
-                    return;
-                }
-
                 mSession = new Session(/* context= */ this);
             } catch (UnavailableArcoreNotInstalledException
                     | UnavailableUserDeclinedInstallationException e) {
@@ -354,16 +347,6 @@ public class DrawAR extends AppCompatActivity implements GLSurfaceView.Renderer,
         getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
         mScreenHeight = displayMetrics.heightPixels;
         mScreenWidth = displayMetrics.widthPixels;
-    }
-
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] results) {
-        if (!PermissionHelper.hasCameraPermission(this)) {
-            Toast.makeText(this,
-                    "Camera permission is needed to run this application", Toast.LENGTH_LONG).show();
-            finish();
-        }
     }
 
     @Override

--- a/app/src/main/java/com/googlecreativelab/drawar/FakeMainActivity.java
+++ b/app/src/main/java/com/googlecreativelab/drawar/FakeMainActivity.java
@@ -1,0 +1,38 @@
+package com.googlecreativelab.drawar;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.widget.Toast;
+
+// ARCore requires camera permissions to operate. We should request the permission before DrawAR because the ARCore's JNI_OnLoad need
+// the permission. If don't request it before DrawAR, the app will crash on the first start.
+public class FakeMainActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (!PermissionHelper.hasCameraPermission(this)) {
+            PermissionHelper.requestCameraPermission(this);
+        }else{
+            startRealActivity();
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] results) {
+        if (!PermissionHelper.hasCameraPermission(this)) {
+            Toast.makeText(this,
+                    "Camera permission is needed to run this application", Toast.LENGTH_LONG).show();
+            finish();
+        }else{
+            startRealActivity();
+        }
+    }
+
+    private void startRealActivity(){
+        Intent intent = new Intent(this,DrawAR.class);
+        startActivity(intent);
+        finish();
+    }
+}


### PR DESCRIPTION
We should request the permission before DrawAR because the ARCore's JNI_OnLoad need the permission. If don't request it before DrawAR, the app will crash on the first start. 