### PR TITLE
Upgrade gradle's and libs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         applicationId "com.googlecreativelab.drawar"
 
         // 24 is the minimum since ARCore only works with 24 and higher.
         minSdkVersion 24
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -22,8 +22,8 @@ android {
 
 dependencies {
     // ARCore library
-    implementation 'com.google.ar:core:1.0.0'
+    implementation 'com.google.ar:core:1.6.0'
     implementation 'javax.vecmath:vecmath:1.5.2'
-    implementation 'com.android.support:appcompat-v7:27.1.0'
-    implementation 'com.android.support:design:27.1.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
 }

--- a/app/src/main/java/com/googlecreativelab/drawar/DrawAR.java
+++ b/app/src/main/java/com/googlecreativelab/drawar/DrawAR.java
@@ -47,6 +47,7 @@ import com.google.ar.core.Config;
 import com.google.ar.core.Frame;
 import com.google.ar.core.Session;
 import com.google.ar.core.TrackingState;
+import com.google.ar.core.exceptions.CameraNotAvailableException;
 import com.google.ar.core.exceptions.UnavailableApkTooOldException;
 import com.google.ar.core.exceptions.UnavailableArcoreNotInstalledException;
 import com.google.ar.core.exceptions.UnavailableSdkTooOldException;
@@ -325,7 +326,11 @@ public class DrawAR extends AppCompatActivity implements GLSurfaceView.Renderer,
             mSession.configure(config);
         }
         // Note that order matters - see the note in onPause(), the reverse applies here.
-        mSession.resume();
+        try {
+            mSession.resume();
+        } catch (CameraNotAvailableException e) {
+            e.printStackTrace();
+        }
         mSurfaceView.onResume();
         mDisplayRotationHelper.onResume();
         mPaused = false;

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 11 17:45:57 EDT 2017
+#Sun Dec 30 02:44:28 EET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip


### PR DESCRIPTION
In this commit I've updated:

-  `com.google.ar:core` to version `1.6.0` which require to call `mSession.resume()` inside try & catch block, which is more safer.
- support libs & target sdk
- gradle.properties version to version `4.10`

In next commit will migrate project to $kotlin.